### PR TITLE
Add bows, crossbows, and mace to be enchanted with telekinesis

### DIFF
--- a/surf-enchantment-api/src/main/kotlin/dev/slne/surf/enchantment/api/utils/CustomItemTypeTags.kt
+++ b/surf-enchantment-api/src/main/kotlin/dev/slne/surf/enchantment/api/utils/CustomItemTypeTags.kt
@@ -81,7 +81,11 @@ enum class CustomItemTypeTags(
         TagEntry.tagEntry(ItemTypeTagKeys.PICKAXES),
         TagEntry.tagEntry(ItemTypeTagKeys.SHOVELS),
         TagEntry.tagEntry(ItemTypeTagKeys.SWORDS),
-        TagEntry.valueEntry(ItemTypeKeys.TRIDENT)
+        TagEntry.valueEntry(ItemTypeKeys.TRIDENT),
+        TagEntry.tagEntry(ItemTypeKeys.BOWS),
+        TagEntry.tagEntry(ItemTypeKeys.CROSSBOWS),
+        TagEntry.tagEntry(ItemTypeKeys.SPEARS),
+        TagEntry.valueEntry(ItemTypeKeys.MACE)
     ),
 
     VEIN_MINER_KEY(


### PR DESCRIPTION
Add missing weapons to be telekinesis enchanted.