### PR TITLE
feat: enable lumberjack enchantment and add cooldown reduction support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=2.2.12-SNAPSHOT
+version=2.2.14-SNAPSHOT

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/SurfEnchantment.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/SurfEnchantment.kt
@@ -1,9 +1,11 @@
 package dev.slne.surf.enchantment.paper
 
 import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
+import dev.slne.surf.api.paper.event.register
 import dev.slne.surf.api.paper.packet.SurfPaperPacketApi
 import dev.slne.surf.enchantment.paper.commands.surfEnchantmentCommand
 import dev.slne.surf.enchantment.paper.enchantment.enchantmentManagerImpl
+import dev.slne.surf.enchantment.paper.listener.IllegalAnvilEnchantmentsListener
 import dev.slne.surf.enchantment.paper.lore.SurfEnchantmentPacketLoreHandler
 import org.bukkit.plugin.java.JavaPlugin
 
@@ -15,10 +17,15 @@ class SurfEnchantment : SuspendingJavaPlugin() {
 
     override suspend fun onEnableAsync() {
         enchantmentManagerImpl.registerEnchantmentListeners()
-        SurfPaperPacketApi.INSTANCE.registerPacketLoreListenerGlobal(this, SurfEnchantmentPacketLoreHandler)
+        SurfPaperPacketApi.INSTANCE.registerPacketLoreListenerGlobal(
+            this,
+            SurfEnchantmentPacketLoreHandler
+        )
         enchantmentManagerImpl.startEnchantmentJobs()
 
         surfEnchantmentCommand()
+
+        IllegalAnvilEnchantmentsListener.register()
     }
 
     override suspend fun onDisableAsync() {

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantment/EnchantmentManagerImpl.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantment/EnchantmentManagerImpl.kt
@@ -65,7 +65,7 @@ class EnchantmentManagerImpl : EnchantmentManager {
         register(ExperienceEnchantment)
         //register(HoleDiggerEnchantment)
         //register(VeinMinerEnchantment)
-//        register(LumberJackEnchantment)
+        register(LumberJackEnchantment)
     }
 
     @InternalEnchantmentApi

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/holedigger/listeners/HoleDiggerListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/holedigger/listeners/HoleDiggerListener.kt
@@ -35,7 +35,7 @@ object HoleDiggerListener : Listener {
         appendSpace()
         variableValue("$secondsLeft Sekunden")
         error(".")
-    }, cooldownExpiration = 10.minutes)
+    }, defaultCooldown = 10.minutes)
 
     private val lastBlockFace = Caffeine.newBuilder()
         .expireAfterWrite(5.minutes)

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/LumberjackEnchantmentImpl.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/LumberjackEnchantmentImpl.kt
@@ -1,5 +1,6 @@
 package dev.slne.surf.enchantment.paper.enchantments.lumberjack
 
+import com.google.auto.service.AutoService
 import dev.slne.surf.api.core.messages.adventure.key
 import dev.slne.surf.api.core.rarity.Rarity
 import dev.slne.surf.enchantment.api.enchantment.AbstractCustomEnchantment
@@ -10,7 +11,7 @@ import io.papermc.paper.registry.keys.tags.EnchantmentTagKeys
 import net.kyori.adventure.text.Component.text
 import org.bukkit.enchantments.Enchantment
 
-//@AutoService(LumberJackEnchantment::class)
+@AutoService(LumberJackEnchantment::class)
 class LumberjackEnchantmentImpl : AbstractCustomEnchantment(
     key = key("surf", "lumberjack"),
     displayName = text("Lumberjack"),
@@ -23,13 +24,6 @@ class LumberjackEnchantmentImpl : AbstractCustomEnchantment(
             variableValue("$MAX_BLOCKS_TO_MINE Blöcke")
             appendSpace()
             darkSpacer("pro Nutzung abgebaut.")
-        }
-        line {
-            darkSpacer("Die Abklingzeit beträgt")
-            appendSpace()
-            variableValue("1.5 Sekunden")
-            appendSpace()
-            darkSpacer("pro abgebautem Block.")
         }
         line {
             darkSpacer("Solltest du den")
@@ -49,7 +43,7 @@ class LumberjackEnchantmentImpl : AbstractCustomEnchantment(
 ), LumberJackEnchantment {
     companion object {
         const val MAX_BLOCKS_TO_MINE = 120
-        const val COOLDOWN_PER_BLOCK_MS = 1500
+        const val COOLDOWN_PER_BLOCK_MS = 3000
         const val INCLUDE_LEAVES = false
     }
 }

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/LumberjackEnchantmentImpl.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/LumberjackEnchantmentImpl.kt
@@ -17,7 +17,7 @@ class LumberjackEnchantmentImpl : AbstractCustomEnchantment(
     displayName = text("Lumberjack"),
     rarity = Rarity.EPIC,
     description = { level ->
-        val blocksToMine = level.coerceIn(1, MAX_LEVEL) * BLOCKS_PER_LEVEL
+        val blocksToMine = blocksForLevel(level)
         val cooldownSeconds = COOLDOWN_MS / 1000
 
         line {
@@ -47,5 +47,7 @@ class LumberjackEnchantmentImpl : AbstractCustomEnchantment(
         const val BLOCKS_PER_LEVEL = 10
         const val COOLDOWN_MS = 20_000
         const val INCLUDE_LEAVES = false
+
+        fun blocksForLevel(level: Int) = level.coerceAtLeast(1) * BLOCKS_PER_LEVEL
     }
 }

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/LumberjackEnchantmentImpl.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/LumberjackEnchantmentImpl.kt
@@ -16,14 +16,16 @@ class LumberjackEnchantmentImpl : AbstractCustomEnchantment(
     key = key("surf", "lumberjack"),
     displayName = text("Lumberjack"),
     rarity = Rarity.EPIC,
-    description = {
-        line { darkSpacer("Bäume werden vollständig und mit einem Schlag abgebaut") }
+    description = { level ->
+        val blocksToMine = level.coerceIn(1, MAX_LEVEL) * BLOCKS_PER_LEVEL
+
+        line { darkSpacer("Ermöglicht es dir alle 20 Sekunden") }
         line {
-            darkSpacer("Es werden maximal")
+            darkSpacer("bis zu")
             appendSpace()
-            variableValue("$MAX_BLOCKS_TO_MINE Blöcke")
+            variableValue("$blocksToMine Blöcke")
             appendSpace()
-            darkSpacer("pro Nutzung abgebaut.")
+            darkSpacer("eines Baumes auf einmal abzubauen.")
         }
         line {
             darkSpacer("Solltest du den")
@@ -38,12 +40,14 @@ class LumberjackEnchantmentImpl : AbstractCustomEnchantment(
     tags = setOf(
         EnchantmentTagKeys.IN_ENCHANTING_TABLE,
     ),
+    maxLevel = MAX_LEVEL,
     listeners = setOf(LumberJackListener),
     jobs = setOf(LumberJackListener.cooldownHandler)
 ), LumberJackEnchantment {
     companion object {
-        const val MAX_BLOCKS_TO_MINE = 120
-        const val COOLDOWN_PER_BLOCK_MS = 1500
+        const val MAX_LEVEL = 5
+        const val BLOCKS_PER_LEVEL = 7
+        const val COOLDOWN_MS = 20_000
         const val INCLUDE_LEAVES = false
     }
 }

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/LumberjackEnchantmentImpl.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/LumberjackEnchantmentImpl.kt
@@ -18,21 +18,19 @@ class LumberjackEnchantmentImpl : AbstractCustomEnchantment(
     rarity = Rarity.EPIC,
     description = { level ->
         val blocksToMine = level.coerceIn(1, MAX_LEVEL) * BLOCKS_PER_LEVEL
+        val cooldownSeconds = COOLDOWN_MS / 1000
 
-        line { darkSpacer("Ermöglicht es dir alle 20 Sekunden") }
+        line {
+            darkSpacer("Ermöglicht es dir alle")
+            appendSpace()
+            variableValue("$cooldownSeconds Sekunden")
+        }
         line {
             darkSpacer("bis zu")
             appendSpace()
             variableValue("$blocksToMine Blöcke")
             appendSpace()
             darkSpacer("eines Baumes auf einmal abzubauen.")
-        }
-        line {
-            darkSpacer("Solltest du den")
-            appendSpace()
-            variableValue("Woodcutting Skill")
-            appendSpace()
-            darkSpacer("gelevelt haben, verkürzt sich der Cooldown.")
         }
     },
     supportedItems = CustomItemTypeTags.LUMBERJACK_KEY.tagKey,
@@ -46,7 +44,7 @@ class LumberjackEnchantmentImpl : AbstractCustomEnchantment(
 ), LumberJackEnchantment {
     companion object {
         const val MAX_LEVEL = 5
-        const val BLOCKS_PER_LEVEL = 7
+        const val BLOCKS_PER_LEVEL = 10
         const val COOLDOWN_MS = 20_000
         const val INCLUDE_LEAVES = false
     }

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/LumberjackEnchantmentImpl.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/LumberjackEnchantmentImpl.kt
@@ -43,7 +43,7 @@ class LumberjackEnchantmentImpl : AbstractCustomEnchantment(
 ), LumberJackEnchantment {
     companion object {
         const val MAX_BLOCKS_TO_MINE = 120
-        const val COOLDOWN_PER_BLOCK_MS = 3000
+        const val COOLDOWN_PER_BLOCK_MS = 1500
         const val INCLUDE_LEAVES = false
     }
 }

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/TreeFinder.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/TreeFinder.kt
@@ -1,13 +1,18 @@
 package dev.slne.surf.enchantment.paper.enchantments.lumberjack
 
 import dev.slne.surf.api.core.util.objectListOf
+import dev.slne.surf.api.paper.pdc.block.pdc
 import org.bukkit.Material
+import org.bukkit.NamespacedKey
 import org.bukkit.Tag
 import org.bukkit.block.Block
 import org.bukkit.block.BlockFace
 import org.bukkit.block.data.type.Leaves
+import org.bukkit.persistence.PersistentDataType
 
 object TreeFinder {
+
+    private val MODIFIED_BLOCK_KEY = NamespacedKey("surf", "skill_modified_block")
 
     private val directions = objectListOf(
         BlockFace.UP, BlockFace.DOWN,
@@ -15,9 +20,13 @@ object TreeFinder {
         BlockFace.EAST, BlockFace.WEST
     )
 
+    fun isEligibleBlock(block: Block): Boolean {
+        return block.pdc().get(MODIFIED_BLOCK_KEY, PersistentDataType.BOOLEAN) != true
+    }
+
     fun findTree(
         start: Block,
-        maxBlocks: Int = LumberjackEnchantmentImpl.MAX_BLOCKS_TO_MINE,
+        maxBlocks: Int = LumberjackEnchantmentImpl.MAX_LEVEL * LumberjackEnchantmentImpl.BLOCKS_PER_LEVEL,
         includeLeaves: Boolean = LumberjackEnchantmentImpl.INCLUDE_LEAVES
     ): Set<Block> {
         val result = LinkedHashSet<Block>()
@@ -34,29 +43,30 @@ object TreeFinder {
 
         while (queue.isNotEmpty() && result.size < maxBlocks) {
             val current = queue.removeFirst()
+            if (!isTreeBlock(current, logType, includeLeaves)) continue
             if (!result.add(current)) continue
 
             for (face in directions) {
                 val relative = current.getRelative(face)
-
-                val type = relative.type
-                val isLog = type == logType
-
-                if (isLog) {
+                if (isTreeBlock(relative, logType, includeLeaves)) {
                     queue.add(relative)
-                    continue
-                }
-
-                if (includeLeaves && Tag.LEAVES.isTagged(type)) {
-                    val data = relative.blockData as? Leaves ?: continue
-                    if (data.distance < 7) {
-                        queue.add(relative)
-                    }
                 }
             }
         }
 
         return result
+    }
+
+    private fun isTreeBlock(block: Block, logType: Material, includeLeaves: Boolean): Boolean {
+        if (!isEligibleBlock(block)) return false
+
+        val type = block.type
+        if (type == logType) return true
+
+        if (!includeLeaves || !Tag.LEAVES.isTagged(type)) return false
+
+        val data = block.blockData as? Leaves ?: return false
+        return data.distance < 7
     }
 
     private fun detect2x2(start: Block, logType: Material): List<Block> {
@@ -72,7 +82,7 @@ object TreeFinder {
                 start.world.getBlockAt(start.x + dx, start.y, start.z + dz)
             }
 
-            if (blocks.all { it.type == logType }) {
+            if (blocks.all { it.type == logType && isEligibleBlock(it) }) {
                 return blocks
             }
         }

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/listeners/LumberJackListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/listeners/LumberJackListener.kt
@@ -1,7 +1,7 @@
 package dev.slne.surf.enchantment.paper.enchantments.lumberjack.listeners
 
 import dev.slne.surf.enchantment.api.enchantments.LumberJackEnchantment
-import dev.slne.surf.enchantment.api.utils.hasCustomEnchantment
+import dev.slne.surf.enchantment.api.utils.getThisEnchantmentOrNull
 import dev.slne.surf.enchantment.paper.enchantments.lumberjack.LumberjackEnchantmentImpl
 import dev.slne.surf.enchantment.paper.enchantments.lumberjack.TreeFinder
 import dev.slne.surf.enchantment.paper.utils.BlockBreakHandler
@@ -42,16 +42,21 @@ object LumberJackListener : Listener {
         if (!player.isSneaking) return
 
         val item = player.inventory.itemInMainHand
+        val enchantmentLevel = item.getThisEnchantmentOrNull<LumberJackEnchantment>()?.first ?: return
+        val blockLimit = enchantmentLevel.coerceIn(
+            1,
+            LumberjackEnchantmentImpl.MAX_LEVEL
+        ) * LumberjackEnchantmentImpl.BLOCKS_PER_LEVEL
 
-        if (!item.hasCustomEnchantment<LumberJackEnchantment>()) return
         val blockToMine = event.block
         if (!Tag.LOGS.isTagged(blockToMine.type)) return
+        if (!TreeFinder.isEligibleBlock(blockToMine)) return
 
         if (player.gameMode != GameMode.CREATIVE) {
             if (!cooldownHandler.checkCooldown(player.uniqueId)) return
         }
 
-        val treeBlocks = TreeFinder.findTree(event.block)
+        val treeBlocks = TreeFinder.findTree(event.block, maxBlocks = blockLimit)
 
         if (treeBlocks.size <= 1) return
 
@@ -59,7 +64,7 @@ object LumberJackListener : Listener {
         val blocksToMine = blockResult.breakableBlocks
 
         BlockBreakHandler.handleBlockBreak(
-            cooldown = (blocksToMine.size * LumberjackEnchantmentImpl.COOLDOWN_PER_BLOCK_MS).milliseconds,
+            cooldown = LumberjackEnchantmentImpl.COOLDOWN_MS.milliseconds,
             blocks = blocksToMine,
             cooldownHandler = cooldownHandler,
             event = event,

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/listeners/LumberJackListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/listeners/LumberJackListener.kt
@@ -19,15 +19,20 @@ import kotlin.time.Duration.Companion.milliseconds
 object LumberJackListener : Listener {
     private val blockHandler = BlockHandler()
 
-    val cooldownHandler = CooldownHandler({
+    val cooldownHandler = CooldownHandler(
+        {
         appendSuccessPrefix()
         success("Die Axt ist wieder geschärft!")
     }, { secondsLeft ->
         appendErrorPrefix()
         error("Die Axt ist noch stumpf vom letzten Baum!")
         appendSpace()
-        error("Bitte warte noch einen Moment.")
-    })
+        error("Bitte warte noch ")
+        variableValue("$secondsLeft Sekunden")
+        error(".")
+    },
+        allowReduction = true
+    )
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     fun onBreak(event: BlockBreakEvent) {

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/listeners/LumberJackListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/listeners/LumberJackListener.kt
@@ -8,6 +8,7 @@ import dev.slne.surf.enchantment.paper.utils.BlockBreakHandler
 import dev.slne.surf.enchantment.paper.utils.BlockHandler
 import dev.slne.surf.enchantment.paper.utils.CooldownHandler
 import dev.slne.surf.enchantment.paper.utils.events.FakeBlockBreakEvent
+import net.kyori.adventure.text.format.TextColor
 import org.bukkit.GameMode
 import org.bukkit.Tag
 import org.bukkit.event.EventHandler
@@ -18,18 +19,19 @@ import kotlin.time.Duration.Companion.milliseconds
 
 object LumberJackListener : Listener {
     private val blockHandler = BlockHandler()
+    private val messageColor = TextColor.color(0xee3d51)
+    private val variableColor = TextColor.color(0xf9c353)
 
     val cooldownHandler = CooldownHandler(
         {
         appendSuccessPrefix()
         success("Die Axt ist wieder geschärft!")
     }, { secondsLeft ->
-        appendErrorPrefix()
-        error("Die Axt ist noch stumpf vom letzten Baum!")
-        appendSpace()
-        error("Bitte warte noch ")
-        variableValue("$secondsLeft Sekunden")
-        error(".")
+        text("Du kannst ", messageColor)
+        text("Lumberjack", variableColor)
+        text(" erst in ", messageColor)
+        text(secondsLeft, variableColor)
+        text(" Sekunden wieder verwenden!", messageColor)
     },
         allowReduction = true
     )

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/listeners/LumberJackListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/listeners/LumberJackListener.kt
@@ -45,10 +45,7 @@ object LumberJackListener : Listener {
 
         val item = player.inventory.itemInMainHand
         val enchantmentLevel = item.getThisEnchantmentOrNull<LumberJackEnchantment>()?.first ?: return
-        val blockLimit = enchantmentLevel.coerceIn(
-            1,
-            LumberjackEnchantmentImpl.MAX_LEVEL
-        ) * LumberjackEnchantmentImpl.BLOCKS_PER_LEVEL
+        val blockLimit = LumberjackEnchantmentImpl.blocksForLevel(enchantmentLevel)
 
         val blockToMine = event.block
         if (!Tag.LOGS.isTagged(blockToMine.type)) return

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/rocketride/listeners/RocketRideBoostListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/rocketride/listeners/RocketRideBoostListener.kt
@@ -24,7 +24,6 @@ import org.bukkit.event.player.PlayerInteractEntityEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.inventory.meta.FireworkMeta
 import org.bukkit.persistence.PersistentDataType
-import kotlin.time.Duration.Companion.seconds
 import org.bukkit.Sound as BukkitSound
 
 object RocketRideBoostListener : Listener {
@@ -120,7 +119,7 @@ object RocketRideBoostListener : Listener {
             item.amount -= 1
         }
 
-        cooldownHandler.applyCooldown(happyGhast.uniqueId, boost.cooldownSeconds.seconds)
+        //cooldownHandler.applyCooldown(player, happyGhast.uniqueId, boost.cooldownSeconds.seconds) TODO: Implement
 
         happyGhast.passengers.forEach { passenger ->
             passenger.sendActionBar(buildText { success("Der Happy Ghast wurde geboostet!") })

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/IllegalAnvilEnchantmentsListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/IllegalAnvilEnchantmentsListener.kt
@@ -1,0 +1,42 @@
+package dev.slne.surf.enchantment.paper.listener
+
+import org.bukkit.enchantments.Enchantment
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.PrepareAnvilEvent
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.EnchantmentStorageMeta
+
+object IllegalAnvilEnchantmentsListener : Listener {
+    @EventHandler
+    fun onAnvilPrepare(event: PrepareAnvilEvent) {
+        val left = event.inventory.firstItem ?: return
+        val right = event.inventory.secondItem ?: return
+
+        if (!isBook(left) || !isBook(right)) {
+            return
+        }
+
+        val leftEnchants = getStoredEnchants(left)
+        val rightEnchants = getStoredEnchants(right)
+
+        for ((enchant, levelLeft) in leftEnchants) {
+            val levelRight = rightEnchants[enchant] ?: continue
+
+            val resultLevel =
+                if (levelLeft == levelRight) levelLeft + 1 else maxOf(levelLeft, levelRight)
+
+            if (resultLevel > enchant.maxLevel) {
+                event.result = null
+                return
+            }
+        }
+    }
+
+    private fun isBook(item: ItemStack) = item.itemMeta is EnchantmentStorageMeta
+
+    private fun getStoredEnchants(item: ItemStack): Map<Enchantment, Int> {
+        val meta = item.itemMeta as? EnchantmentStorageMeta ?: return emptyMap()
+        return meta.storedEnchants
+    }
+}

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/utils/BlockBreakHandler.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/utils/BlockBreakHandler.kt
@@ -24,7 +24,7 @@ object BlockBreakHandler {
 
         if (player.gameMode != GameMode.CREATIVE) {
             cooldownHandler.applyCooldown(
-                player.uniqueId,
+                player,
                 cooldown
             )
 

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/utils/CooldownHandler.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/utils/CooldownHandler.kt
@@ -6,19 +6,25 @@ import dev.slne.surf.api.core.messages.adventure.sendText
 import dev.slne.surf.api.core.messages.builder.SurfComponentBuilder
 import dev.slne.surf.api.paper.extensions.server
 import dev.slne.surf.enchantment.api.enchantment.EnchantmentJob
+import dev.slne.surf.enchantment.api.enchantment.EnchantmentManager.Companion.launch
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.coroutineScope
+import org.bukkit.NamespacedKey
 import org.bukkit.entity.Player
+import org.bukkit.persistence.PersistentDataType
 import java.time.OffsetDateTime
 import java.util.*
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
+private val lumberJackReductionKey =
+    NamespacedKey("surf-skill-paper", "lumberjack_cooldown_reduction")
+
 class CooldownHandler(
     private val expirationMessage: SurfComponentBuilder.() -> Unit = {},
     private val notReadyMessage: SurfComponentBuilder.(Long) -> Unit = {},
-    cooldownExpiration: Duration = 5.minutes,
+    private val defaultCooldown: Duration = 5.minutes,
+    private val allowReduction: Boolean = false,
     lastMessageExpiration: Duration = 3.seconds
 ) : EnchantmentJob() {
     private val expirationListeners = mutableListOf<suspend CoroutineScope.(UUID) -> Unit>()
@@ -29,38 +35,41 @@ class CooldownHandler(
         .build<UUID, Unit>()
 
     private val cooldowns = Caffeine.newBuilder()
-        .expireAfterWrite(cooldownExpiration)
         .maximumSize(10_000)
         .build<UUID, OffsetDateTime>()
 
     override suspend fun tick() {
         val now = OffsetDateTime.now()
 
-        cooldowns.asMap().forEach { (uuid, expireTime) ->
-            if (expireTime.isBefore(now)) {
-                cooldowns.invalidate(uuid)
+        cooldowns.asMap().entries.removeIf { (uuid, expireTime) ->
+            if (expireTime.isAfter(now)) return@removeIf false
 
-                server.getPlayer(uuid)?.sendText(expirationMessage)
+            server.getPlayer(uuid)?.sendText(expirationMessage)
 
-                coroutineScope {
-                    expirationListeners.forEach { listener ->
-                        listener.invoke(this, uuid)
-                    }
+            expirationListeners.forEach { listener ->
+                launch {
+                    listener(uuid)
                 }
             }
+            true
         }
     }
 
     fun checkCooldown(uuid: UUID, receiverPlayer: Player? = null): Boolean {
         val expireTime = cooldowns.getIfPresent(uuid) ?: return true
 
-        if (lastMessage.getIfPresent(uuid) == null) {
-            val secondsLeft = expireTime.toEpochSecond() - OffsetDateTime.now().toEpochSecond()
+        val remaining = expireTime.toEpochSecond() - OffsetDateTime.now().toEpochSecond()
 
+        if (remaining <= 0) {
+            cooldowns.invalidate(uuid)
+            return true
+        }
+
+        if (lastMessage.getIfPresent(uuid) == null) {
             val player = receiverPlayer ?: server.getPlayer(uuid)
 
             player?.sendText {
-                notReadyMessage(this, secondsLeft)
+                notReadyMessage(this, remaining)
             }
 
             lastMessage.put(uuid, Unit)
@@ -69,8 +78,30 @@ class CooldownHandler(
         return false
     }
 
-    fun applyCooldown(uuid: UUID, cooldown: Duration) {
-        cooldowns.put(uuid, OffsetDateTime.now().plusSeconds(cooldown.inWholeSeconds))
+    fun applyCooldown(player: Player, cooldown: Duration = defaultCooldown) {
+        val uuid = player.uniqueId
+
+        if (!allowReduction) {
+            cooldowns.put(
+                uuid,
+                OffsetDateTime.now().plusSeconds(cooldown.inWholeSeconds)
+            )
+            return
+        }
+
+        val reductionSeconds = player.persistentDataContainer.get(
+            lumberJackReductionKey,
+            PersistentDataType.DOUBLE
+        ) ?: 0.0
+
+        val finalCooldown = cooldown
+            .minus(reductionSeconds.seconds)
+            .coerceAtLeast(0.seconds)
+
+        cooldowns.put(
+            uuid,
+            OffsetDateTime.now().plusSeconds(finalCooldown.inWholeSeconds)
+        )
     }
 
     fun invalidateCooldown(uuid: UUID) {


### PR DESCRIPTION
- Register LumberjackEnchantment and enable its listener
- Update CooldownHandler to support per-player cooldown reduction via PersistentDataContainer
- Refactor applyCooldown to accept Player and handle reduction logic
- Adjust cooldown messaging for clarity and consistency
- Update Lumberjack and HoleDigger listeners to use new CooldownHandler parameters
- Increase LumberjackEnchantment cooldown per block to 3 seconds