### PR TITLE
Fix event-only enchantment obtainability

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=2.2.19
+version=2.2.20

--- a/surf-enchantment-api/src/main/kotlin/dev/slne/surf/enchantment/api/enchantment/AbstractCustomEnchantment.kt
+++ b/surf-enchantment-api/src/main/kotlin/dev/slne/surf/enchantment/api/enchantment/AbstractCustomEnchantment.kt
@@ -42,6 +42,7 @@ abstract class AbstractCustomEnchantment(
     override val activeSlots: Set<EquipmentSlotGroup> = objectSetOf(EquipmentSlotGroup.ANY),
     override val exclusiveWith: Set<Key>? = null,
     override val tags: Set<TagKey<Enchantment>>? = objectSetOf(),
+    override val obtainableFromGameplay: Boolean = true,
     override val typedKey: TypedKey<Enchantment> = TypedKey.create(RegistryKey.ENCHANTMENT, key),
     override val listeners: Set<Listener> = objectSetOf(),
     override val jobs: Set<EnchantmentJob> = objectSetOf(),

--- a/surf-enchantment-api/src/main/kotlin/dev/slne/surf/enchantment/api/enchantment/CustomEnchantment.kt
+++ b/surf-enchantment-api/src/main/kotlin/dev/slne/surf/enchantment/api/enchantment/CustomEnchantment.kt
@@ -29,6 +29,16 @@ interface CustomEnchantment : Enchantable {
     val activeSlots: Set<EquipmentSlotGroup>?
     val exclusiveWith: Set<Key>?
     val tags: Set<TagKey<Enchantment>>?
+
+    /**
+     * Controls whether this enchantment may be exposed through vanilla gameplay sources
+     * such as enchanting tables, generated loot, mob equipment or trades.
+     *
+     * Event-only enchantments should set this to false and must not be assigned
+     * gameplay source tags.
+     */
+    val obtainableFromGameplay: Boolean
+
     val typedKey: TypedKey<Enchantment>
 
     val bukkitEnchantment: Enchantment

--- a/surf-enchantment-api/src/main/kotlin/dev/slne/surf/enchantment/api/enchantment/CustomEnchantment.kt
+++ b/surf-enchantment-api/src/main/kotlin/dev/slne/surf/enchantment/api/enchantment/CustomEnchantment.kt
@@ -37,7 +37,7 @@ interface CustomEnchantment : Enchantable {
      * Event-only enchantments should set this to false and must not be assigned
      * gameplay source tags.
      */
-    val obtainableFromGameplay: Boolean
+    val obtainableFromGameplay: Boolean get() = true
 
     val typedKey: TypedKey<Enchantment>
 

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/SurfEnchantment.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/SurfEnchantment.kt
@@ -5,6 +5,7 @@ import dev.slne.surf.api.paper.event.register
 import dev.slne.surf.api.paper.packet.SurfPaperPacketApi
 import dev.slne.surf.enchantment.paper.commands.surfEnchantmentCommand
 import dev.slne.surf.enchantment.paper.enchantment.enchantmentManagerImpl
+import dev.slne.surf.enchantment.paper.listener.GameplayObtainabilityListener
 import dev.slne.surf.enchantment.paper.listener.IllegalAnvilEnchantmentsListener
 import dev.slne.surf.enchantment.paper.lore.SurfEnchantmentPacketLoreHandler
 import org.bukkit.plugin.java.JavaPlugin
@@ -26,6 +27,7 @@ class SurfEnchantment : SuspendingJavaPlugin() {
         surfEnchantmentCommand()
 
         IllegalAnvilEnchantmentsListener.register()
+        GameplayObtainabilityListener.register()
     }
 
     override suspend fun onDisableAsync() {

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/bootstrap/TagPostFlattenHandler.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/bootstrap/TagPostFlattenHandler.kt
@@ -3,6 +3,7 @@
 package dev.slne.surf.enchantment.paper.bootstrap
 
 import dev.slne.surf.api.core.util.objectSetOf
+import dev.slne.surf.enchantment.api.enchantment.CustomEnchantment
 import dev.slne.surf.enchantment.api.enchantment.EnchantmentManager
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents
 import io.papermc.paper.registry.RegistryKey
@@ -31,11 +32,7 @@ fun tagPostFlattenHandler() =
         }
     }
 
-private fun EnchantmentManager.CustomEnchantmentNotUsed() = Unit
-
-private fun dev.slne.surf.enchantment.api.enchantment.CustomEnchantment.validateGameplayTags(
-    tags: Set<TagKey<Enchantment>>
-) {
+private fun CustomEnchantment.validateGameplayTags(tags: Set<TagKey<Enchantment>>) {
     if (obtainableFromGameplay) return
 
     val blockedTags = tags.filter { it in GAMEPLAY_SOURCE_TAGS }

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/bootstrap/TagPostFlattenHandler.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/bootstrap/TagPostFlattenHandler.kt
@@ -6,15 +6,40 @@ import dev.slne.surf.api.core.util.objectSetOf
 import dev.slne.surf.enchantment.api.enchantment.EnchantmentManager
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents
 import io.papermc.paper.registry.RegistryKey
+import io.papermc.paper.registry.keys.tags.EnchantmentTagKeys
+import io.papermc.paper.registry.tag.TagKey
+import org.bukkit.enchantments.Enchantment
+
+private val GAMEPLAY_SOURCE_TAGS = objectSetOf(
+    EnchantmentTagKeys.IN_ENCHANTING_TABLE,
+    EnchantmentTagKeys.ON_MOB_SPAWN_EQUIPMENT,
+    EnchantmentTagKeys.ON_RANDOM_LOOT,
+    EnchantmentTagKeys.TRADEABLE,
+    EnchantmentTagKeys.TREASURE,
+)
 
 fun tagPostFlattenHandler() =
     LifecycleEvents.TAGS.postFlatten(RegistryKey.ENCHANTMENT).newHandler { event ->
         val registrar = event.registrar()
         for (enchantment in EnchantmentManager.customEnchantments) {
             val tags = enchantment.tags ?: continue
+            enchantment.validateGameplayTags(tags)
 
             for (tag in tags) {
                 registrar.addToTag(tag, objectSetOf(enchantment.typedKey))
             }
         }
     }
+
+private fun EnchantmentManager.CustomEnchantmentNotUsed() = Unit
+
+private fun dev.slne.surf.enchantment.api.enchantment.CustomEnchantment.validateGameplayTags(
+    tags: Set<TagKey<Enchantment>>
+) {
+    if (obtainableFromGameplay) return
+
+    val blockedTags = tags.filter { it in GAMEPLAY_SOURCE_TAGS }
+    require(blockedTags.isEmpty()) {
+        "Enchantment $key is marked as not obtainable from gameplay, but is assigned to gameplay source tags: $blockedTags"
+    }
+}

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/bootstrap/TagPostFlattenHandler.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/bootstrap/TagPostFlattenHandler.kt
@@ -35,7 +35,7 @@ fun tagPostFlattenHandler() =
 private fun CustomEnchantment.validateGameplayTags(tags: Set<TagKey<Enchantment>>) {
     if (obtainableFromGameplay) return
 
-    val blockedTags = tags.filter { it in GAMEPLAY_SOURCE_TAGS }
+    val blockedTags = tags.intersect(GAMEPLAY_SOURCE_TAGS)
     require(blockedTags.isEmpty()) {
         "Enchantment $key is marked as not obtainable from gameplay, but is assigned to gameplay source tags: $blockedTags"
     }

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantment/EnchantmentManagerImpl.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantment/EnchantmentManagerImpl.kt
@@ -60,7 +60,7 @@ class EnchantmentManagerImpl : EnchantmentManager {
         register(SilentNightEnchantment)
         register(SilentGazeEnchantment)
         register(BeheadingEnchantment)
-        //register(RocketSaverEnchantment)
+        register(RocketSaverEnchantment)
         //register(RocketRideEnchantment)
         register(ExperienceEnchantment)
         //register(HoleDiggerEnchantment)

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/rocketride/listeners/RocketRideBoostListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/rocketride/listeners/RocketRideBoostListener.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 package dev.slne.surf.enchantment.paper.enchantments.rocketride.listeners
 
 import dev.slne.surf.api.core.messages.adventure.buildText
@@ -9,6 +11,7 @@ import dev.slne.surf.enchantment.api.utils.hasCustomEnchantment
 import dev.slne.surf.enchantment.paper.enchantments.rocketride.RocketBoost
 import dev.slne.surf.enchantment.paper.enchantments.rocketride.RocketRideBoostService
 import dev.slne.surf.enchantment.paper.utils.CooldownHandler
+import io.papermc.paper.datacomponent.DataComponentTypes
 import kotlinx.coroutines.withContext
 import net.kyori.adventure.sound.Sound
 import org.bukkit.GameMode
@@ -22,7 +25,6 @@ import org.bukkit.event.entity.EntityDeathEvent
 import org.bukkit.event.entity.EntityDropItemEvent
 import org.bukkit.event.player.PlayerInteractEntityEvent
 import org.bukkit.event.player.PlayerInteractEvent
-import org.bukkit.inventory.meta.FireworkMeta
 import org.bukkit.persistence.PersistentDataType
 import org.bukkit.Sound as BukkitSound
 
@@ -103,8 +105,7 @@ object RocketRideBoostListener : Listener {
 
         if (!cooldownHandler.checkCooldown(happyGhast.uniqueId, player)) return
 
-        val rocketMeta = item.itemMeta as? FireworkMeta ?: return
-        val tier = rocketMeta.power.coerceIn(1, 3)
+        val tier = (item.getData(DataComponentTypes.FIREWORKS)?.flightDuration() ?: return).coerceIn(1, 3)
         val boost = ROCKET_PROPERTIES[tier] ?: ROCKET_PROPERTIES[1]!!
 
         RocketRideBoostService.startBoost(

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/rocketsaver/RocketSaverEnchantmentImpl.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/rocketsaver/RocketSaverEnchantmentImpl.kt
@@ -2,6 +2,7 @@
 
 package dev.slne.surf.enchantment.paper.enchantments.rocketsaver
 
+import com.google.auto.service.AutoService
 import dev.slne.surf.api.core.messages.adventure.key
 import dev.slne.surf.api.core.messages.adventure.text
 import dev.slne.surf.api.core.rarity.Rarity
@@ -12,7 +13,7 @@ import dev.slne.surf.enchantment.paper.enchantments.rocketsaver.listeners.Rocket
 import io.papermc.paper.registry.data.EnchantmentRegistryEntry
 import org.bukkit.inventory.EquipmentSlotGroup
 
-//@AutoService(RocketSaverEnchantment::class)
+@AutoService(RocketSaverEnchantment::class)
 class RocketSaverEnchantmentImpl : AbstractCustomEnchantment(
     key = key("surf", "rocket_saver"),
     displayName = text("Rocket Saver"),
@@ -39,6 +40,7 @@ class RocketSaverEnchantmentImpl : AbstractCustomEnchantment(
     ),
     activeSlots = setOf(EquipmentSlotGroup.CHEST),
     maxLevel = 3,
+    obtainableFromGameplay = false,
     listeners = setOf(RocketSaverListener)
 ), RocketSaverEnchantment {
     companion object {

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/GameplayObtainabilityListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/GameplayObtainabilityListener.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.enchantment.paper.listener
 import dev.slne.surf.enchantment.api.enchantment.EnchantmentManager
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.enchantment.EnchantItemEvent
 import org.bukkit.event.world.LootGenerateEvent
@@ -10,7 +11,7 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.EnchantmentStorageMeta
 
 object GameplayObtainabilityListener : Listener {
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     fun onLootGenerate(event: LootGenerateEvent) {
         val blockedEnchantments = blockedGameplayEnchantments()
         if (blockedEnchantments.isEmpty()) return
@@ -20,7 +21,7 @@ object GameplayObtainabilityListener : Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     fun onEnchantItem(event: EnchantItemEvent) {
         val blockedEnchantments = blockedGameplayEnchantments()
         if (blockedEnchantments.isEmpty()) return

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/GameplayObtainabilityListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/GameplayObtainabilityListener.kt
@@ -1,0 +1,55 @@
+package dev.slne.surf.enchantment.paper.listener
+
+import dev.slne.surf.enchantment.api.enchantment.EnchantmentManager
+import org.bukkit.enchantments.Enchantment
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.enchantment.EnchantItemEvent
+import org.bukkit.event.world.LootGenerateEvent
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.EnchantmentStorageMeta
+
+object GameplayObtainabilityListener : Listener {
+    @EventHandler
+    fun onLootGenerate(event: LootGenerateEvent) {
+        val blockedEnchantments = blockedGameplayEnchantments()
+        if (blockedEnchantments.isEmpty()) return
+
+        event.loot.forEach { item ->
+            item.removeBlockedEnchantments(blockedEnchantments)
+        }
+    }
+
+    @EventHandler
+    fun onEnchantItem(event: EnchantItemEvent) {
+        val blockedEnchantments = blockedGameplayEnchantments()
+        if (blockedEnchantments.isEmpty()) return
+
+        event.enchantsToAdd.keys.removeAll(blockedEnchantments)
+    }
+
+    private fun blockedGameplayEnchantments() = EnchantmentManager.customEnchantments
+        .filterNot { it.obtainableFromGameplay }
+        .mapTo(mutableSetOf()) { it.bukkitEnchantment }
+
+    private fun ItemStack.removeBlockedEnchantments(blockedEnchantments: Set<Enchantment>) {
+        for (enchantment in enchantments.keys) {
+            if (enchantment in blockedEnchantments) {
+                removeEnchantment(enchantment)
+            }
+        }
+
+        val storageMeta = itemMeta as? EnchantmentStorageMeta ?: return
+        var changed = false
+        for (enchantment in storageMeta.storedEnchants.keys) {
+            if (enchantment in blockedEnchantments) {
+                storageMeta.removeStoredEnchant(enchantment)
+                changed = true
+            }
+        }
+
+        if (changed) {
+            itemMeta = storageMeta
+        }
+    }
+}

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/GameplayObtainabilityListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/GameplayObtainabilityListener.kt
@@ -33,7 +33,7 @@ object GameplayObtainabilityListener : Listener {
         .mapTo(mutableSetOf()) { it.bukkitEnchantment }
 
     private fun ItemStack.removeBlockedEnchantments(blockedEnchantments: Set<Enchantment>) {
-        for (enchantment in enchantments.keys) {
+        for (enchantment in enchantments.keys.toList()) {
             if (enchantment in blockedEnchantments) {
                 removeEnchantment(enchantment)
             }
@@ -41,7 +41,7 @@ object GameplayObtainabilityListener : Listener {
 
         val storageMeta = itemMeta as? EnchantmentStorageMeta ?: return
         var changed = false
-        for (enchantment in storageMeta.storedEnchants.keys) {
+        for (enchantment in storageMeta.storedEnchants.keys.toList()) {
             if (enchantment in blockedEnchantments) {
                 storageMeta.removeStoredEnchant(enchantment)
                 changed = true

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/GameplayObtainabilityListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/GameplayObtainabilityListener.kt
@@ -1,6 +1,10 @@
+@file:Suppress("UnstableApiUsage")
+
 package dev.slne.surf.enchantment.paper.listener
 
 import dev.slne.surf.enchantment.api.enchantment.EnchantmentManager
+import io.papermc.paper.datacomponent.DataComponentTypes
+import io.papermc.paper.datacomponent.item.ItemEnchantments
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
@@ -8,7 +12,6 @@ import org.bukkit.event.Listener
 import org.bukkit.event.enchantment.EnchantItemEvent
 import org.bukkit.event.world.LootGenerateEvent
 import org.bukkit.inventory.ItemStack
-import org.bukkit.inventory.meta.EnchantmentStorageMeta
 
 object GameplayObtainabilityListener : Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -34,23 +37,20 @@ object GameplayObtainabilityListener : Listener {
         .mapTo(mutableSetOf()) { it.bukkitEnchantment }
 
     private fun ItemStack.removeBlockedEnchantments(blockedEnchantments: Set<Enchantment>) {
-        for (enchantment in enchantments.keys.toList()) {
-            if (enchantment in blockedEnchantments) {
-                removeEnchantment(enchantment)
+        val enchants = getData(DataComponentTypes.ENCHANTMENTS)
+        if (enchants != null) {
+            val filtered = enchants.enchantments().filterKeys { it !in blockedEnchantments }
+            if (filtered.size < enchants.enchantments().size) {
+                setData(DataComponentTypes.ENCHANTMENTS, ItemEnchantments.itemEnchantments(filtered, enchants.showInTooltip()))
             }
         }
 
-        val storageMeta = itemMeta as? EnchantmentStorageMeta ?: return
-        var changed = false
-        for (enchantment in storageMeta.storedEnchants.keys.toList()) {
-            if (enchantment in blockedEnchantments) {
-                storageMeta.removeStoredEnchant(enchantment)
-                changed = true
+        val storedEnchants = getData(DataComponentTypes.STORED_ENCHANTMENTS)
+        if (storedEnchants != null) {
+            val filtered = storedEnchants.enchantments().filterKeys { it !in blockedEnchantments }
+            if (filtered.size < storedEnchants.enchantments().size) {
+                setData(DataComponentTypes.STORED_ENCHANTMENTS, ItemEnchantments.itemEnchantments(filtered, storedEnchants.showInTooltip()))
             }
-        }
-
-        if (changed) {
-            itemMeta = storageMeta
         }
     }
 }

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/GameplayObtainabilityListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/GameplayObtainabilityListener.kt
@@ -14,41 +14,43 @@ import org.bukkit.event.world.LootGenerateEvent
 import org.bukkit.inventory.ItemStack
 
 object GameplayObtainabilityListener : Listener {
+    private val blockedEnchantments: Set<Enchantment> by lazy {
+        EnchantmentManager.customEnchantments
+            .filterNot { it.obtainableFromGameplay }
+            .mapTo(mutableSetOf()) { it.bukkitEnchantment }
+    }
+
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     fun onLootGenerate(event: LootGenerateEvent) {
-        val blockedEnchantments = blockedGameplayEnchantments()
         if (blockedEnchantments.isEmpty()) return
 
         event.loot.forEach { item ->
-            item.removeBlockedEnchantments(blockedEnchantments)
+            item.removeBlockedEnchantments()
         }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     fun onEnchantItem(event: EnchantItemEvent) {
-        val blockedEnchantments = blockedGameplayEnchantments()
         if (blockedEnchantments.isEmpty()) return
 
         event.enchantsToAdd.keys.removeAll(blockedEnchantments)
     }
 
-    private fun blockedGameplayEnchantments() = EnchantmentManager.customEnchantments
-        .filterNot { it.obtainableFromGameplay }
-        .mapTo(mutableSetOf()) { it.bukkitEnchantment }
-
-    private fun ItemStack.removeBlockedEnchantments(blockedEnchantments: Set<Enchantment>) {
+    private fun ItemStack.removeBlockedEnchantments() {
         val enchants = getData(DataComponentTypes.ENCHANTMENTS)
         if (enchants != null) {
-            val filtered = enchants.enchantments().filterKeys { it !in blockedEnchantments }
-            if (filtered.size < enchants.enchantments().size) {
+            val original = enchants.enchantments()
+            val filtered = original.filterKeys { it !in blockedEnchantments }
+            if (filtered.size < original.size) {
                 setData(DataComponentTypes.ENCHANTMENTS, ItemEnchantments.itemEnchantments(filtered, enchants.showInTooltip()))
             }
         }
 
         val storedEnchants = getData(DataComponentTypes.STORED_ENCHANTMENTS)
         if (storedEnchants != null) {
-            val filtered = storedEnchants.enchantments().filterKeys { it !in blockedEnchantments }
-            if (filtered.size < storedEnchants.enchantments().size) {
+            val original = storedEnchants.enchantments()
+            val filtered = original.filterKeys { it !in blockedEnchantments }
+            if (filtered.size < original.size) {
                 setData(DataComponentTypes.STORED_ENCHANTMENTS, ItemEnchantments.itemEnchantments(filtered, storedEnchants.showInTooltip()))
             }
         }

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/IllegalAnvilEnchantmentsListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/listener/IllegalAnvilEnchantmentsListener.kt
@@ -1,11 +1,13 @@
+@file:Suppress("UnstableApiUsage")
+
 package dev.slne.surf.enchantment.paper.listener
 
+import io.papermc.paper.datacomponent.DataComponentTypes
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.inventory.PrepareAnvilEvent
 import org.bukkit.inventory.ItemStack
-import org.bukkit.inventory.meta.EnchantmentStorageMeta
 
 object IllegalAnvilEnchantmentsListener : Listener {
     @EventHandler
@@ -33,10 +35,9 @@ object IllegalAnvilEnchantmentsListener : Listener {
         }
     }
 
-    private fun isBook(item: ItemStack) = item.itemMeta is EnchantmentStorageMeta
+    private fun isBook(item: ItemStack) = item.hasData(DataComponentTypes.STORED_ENCHANTMENTS)
 
     private fun getStoredEnchants(item: ItemStack): Map<Enchantment, Int> {
-        val meta = item.itemMeta as? EnchantmentStorageMeta ?: return emptyMap()
-        return meta.storedEnchants
+        return item.getData(DataComponentTypes.STORED_ENCHANTMENTS)?.enchantments() ?: emptyMap()
     }
 }


### PR DESCRIPTION
## Summary
- add an explicit `obtainableFromGameplay` flag to custom enchantments
- prevent enchantments marked as not gameplay-obtainable from being assigned to Paper gameplay source tags (`IN_ENCHANTING_TABLE`, `ON_RANDOM_LOOT`, mob spawn equipment, trades, treasure)
- re-enable Rocket Saver registration and mark it as event-only via `obtainableFromGameplay = false`
- add a runtime safety net that strips event-only enchantments from generated loot and enchanting-table results

## Why
Rocket Saver should be registered and usable for event rewards, but it must not appear through natural gameplay sources such as loot tables, suspicious sand, enchanting tables, mob equipment, or trades. Previously the only safe workaround was commenting out the service/manager registration, which made the enchantment unavailable entirely.

## Datapack finding
The uploaded custom structures datapack does not directly reference `surf:rocket_saver`, but it contains many loot tables that call generic Minecraft enchantment functions such as `minecraft:enchant_randomly` and `minecraft:enchant_with_levels`. Several of those use `options: "#minecraft:on_random_loot"`. That means a registered custom enchantment can be selected indirectly if it is considered valid for random loot.

## Notes
The tag guard fails fast during tag registration if an event-only enchantment is accidentally assigned to one of the gameplay source tags later. The runtime listener is a defensive fallback for loot/enchant generation from datapacks or vanilla mechanics.

## Testing
- Not run locally; changes were made through the GitHub connector.
- Datapack was inspected from the uploaded zip and contains generic enchantment-generation loot functions.