### PR TITLE
fix: allow Lumberjack with Silk Touch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=2.2.18
+version=2.2.19

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/LumberjackEnchantmentImpl.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/lumberjack/LumberjackEnchantmentImpl.kt
@@ -12,7 +12,6 @@ import dev.slne.surf.enchantment.paper.enchantments.lumberjack.listeners.LumberJ
 import io.papermc.paper.registry.data.EnchantmentRegistryEntry
 import io.papermc.paper.registry.keys.tags.EnchantmentTagKeys
 import net.kyori.adventure.text.Component.text
-import org.bukkit.enchantments.Enchantment
 
 @AutoService(LumberJackEnchantment::class)
 class LumberjackEnchantmentImpl : AbstractCustomEnchantment(
@@ -46,7 +45,6 @@ class LumberjackEnchantmentImpl : AbstractCustomEnchantment(
         65,
         9
     ),
-    exclusiveWith = setOf(Enchantment.SILK_TOUCH.key()),
     tags = setOf(
         EnchantmentTagKeys.IN_ENCHANTING_TABLE,
     ),


### PR DESCRIPTION
## Summary
- remove Silk Touch from Lumberjack's exclusive enchantments so both can be combined
- bump version from `2.2.18` to `2.2.19`

Closes #45.

## Testing
- Not run (small metadata/configuration change only).