### PR TITLE
🐛 fix(TelekinesisListener): update event handler priority and ignore …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=2.2.22
+version=2.2.23

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/telekinesis/listeners/TelekinesisListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/telekinesis/listeners/TelekinesisListener.kt
@@ -57,7 +57,7 @@ object TelekinesisListener : Listener {
         event.items.clear()
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     fun onEntityDeath(event: EntityDeathEvent) {
         val player = event.entity.killer ?: return
         if (!player.inventory.itemInMainHand.hasCustomEnchantment<TelekinesisEnchantment>()) return

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/telekinesis/listeners/TelekinesisListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/telekinesis/listeners/TelekinesisListener.kt
@@ -57,7 +57,7 @@ object TelekinesisListener : Listener {
         event.items.clear()
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST)
     fun onEntityDeath(event: EntityDeathEvent) {
         val player = event.entity.killer ?: return
         if (!player.inventory.itemInMainHand.hasCustomEnchantment<TelekinesisEnchantment>()) return

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/telekinesis/listeners/TelekinesisListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/telekinesis/listeners/TelekinesisListener.kt
@@ -57,8 +57,10 @@ object TelekinesisListener : Listener {
         event.items.clear()
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     fun onEntityDeath(event: EntityDeathEvent) {
+        if (event.isCancelled) return
+
         val player = event.entity.killer ?: return
         if (!player.inventory.itemInMainHand.hasCustomEnchantment<TelekinesisEnchantment>()) return
 


### PR DESCRIPTION
…cancelled events

- set priority to HIGHEST for onEntityDeath event handler
- ignore cancelled events to ensure proper handling