### PR TITLE
ci: publish surf-enchantment plugin artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,5 +10,5 @@ jobs:
   build:
     uses: SLNE-Development/surf-workflows/.github/workflows/build-publish-release-gradle.yml@master
     with:
-      modules: "surf-enchantment-paper-*-all.jar"
+      modules: "surf-enchantment-paper-*-all.jar;surf-enchantment-*-all.jar"
     secrets: inherit


### PR DESCRIPTION
## Summary
- extend the shared publish workflow `modules` input to include the surf-enchantment plugin artifact pattern
- keep the existing shared workflow setup and inherited secrets

## Reference
- follows the surf-skills workflow pattern of passing semicolon-separated JAR patterns to `build-publish-release-gradle.yml`

## Testing
- Not run locally; workflow-only change made through the GitHub connector.