### PR TITLE
🐛 fix(TelekinesisListener): handle cancelled entity death events in t…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=2.2.23
+version=2.2.24

--- a/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/telekinesis/listeners/TelekinesisListener.kt
+++ b/surf-enchantment-paper/src/main/kotlin/dev/slne/surf/enchantment/paper/enchantments/telekinesis/listeners/TelekinesisListener.kt
@@ -36,6 +36,8 @@ object TelekinesisListener : Listener {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     fun onBlockBreak(event: BlockBreakEvent) {
+        if (event.isCancelled) return
+
         val player = event.player
 
         if (!player.inventory.itemInMainHand.hasCustomEnchantment<TelekinesisEnchantment>()) return
@@ -44,8 +46,10 @@ object TelekinesisListener : Listener {
         event.expToDrop = 0
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     fun onBlockDrop(event: BlockDropItemEvent) {
+        if (event.isCancelled) return
+
         val player = event.player
         if (!player.inventory.itemInMainHand.hasCustomEnchantment<TelekinesisEnchantment>()) return
 


### PR DESCRIPTION
…elekinesis enchantment

- add ignoreCancelled flag to entity death event handler
- prevent processing if the event is cancelled
- bump version